### PR TITLE
Partial version ranges are equivalent to glob x ranges

### DIFF
--- a/range.go
+++ b/range.go
@@ -90,7 +90,7 @@ func MustParseGlobVersion(str string) *GlobVersion {
 // Returns an error if it cannot be parsed
 func ParseGlobVersion(str string) (*GlobVersion, error) {
 	isGlob := func(str string) bool {
-		globs := map[string]bool{"*": true, "x": true, "X": true}
+		globs := map[string]bool{"*": true, "x": true, "X": true, "": true}
 		_, ok := globs[str]
 		return ok
 	}

--- a/range_test.go
+++ b/range_test.go
@@ -74,13 +74,13 @@ var rangeTestBattery = map[string]map[string]bool{
 	"=1.3": {
 		"1.3.0": true,
 		"1.3":   true,
-		"1.3.1": false,
+		"1.3.1": true,
 		"2.3":   false,
 	},
 	"1.3": {
 		"1.3.0": true,
 		"1.3":   true,
-		"1.3.1": false,
+		"1.3.1": true,
 		"2.3":   false,
 	},
 	"1.3.2 - 1.4.1": {


### PR DESCRIPTION
1.3 should be equivalent to 1.3.x (not to =1.3.0)